### PR TITLE
Add changes that allow for SQ 7.7 install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ sonar_download_validate_certs: true
 sonar_version: 4.5.6
 sonar_download_url: "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-{{ sonar_version }}.zip"
 sonar_version_directory: "sonarqube-{{ sonar_version }}"
+sonar_directory: /usr/local/sonar
 
 sonar_web_context: ''
 
@@ -21,3 +22,7 @@ sonar_mysql_allowed_hosts:
   - "127.0.0.1"
   - "::1"
   - "localhost"
+
+# Sonar run user and group.
+sonar_run_user: root
+sonar_run_group: root

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure SonarQube JDBC settings for MySQL.
   lineinfile:
-    dest: /usr/local/sonar/conf/sonar.properties
+    dest: "{{ sonar_directory }}/conf/sonar.properties"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   notify: restart sonar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,25 +23,33 @@
     src: "{{ workspace }}/{{ sonar_version_directory }}.zip"
     dest: /usr/local/
     copy: false
-    creates: /usr/local/sonar/COPYING
+    creates: "{{ sonar_directory }}/COPYING"
+    owner: "{{ sonar_run_user }}"
+    group: "{{ sonar_run_group }}"
 
 - name: Move Sonar into place.
   command: >
-    mv /usr/local/{{ sonar_version_directory }} /usr/local/sonar
-    creates=/usr/local/sonar/COPYING
+    mv /usr/local/{{ sonar_version_directory }} {{ sonar_directory }}
+
+- name: Change RUNUSER.
+  lineinfile:
+    dest: "{{ sonar_directory }}/bin/linux-x86-64/sonar.sh"
+    regexp: "^#RUN_AS_USER=$"
+    line: "RUN_AS_USER={{ sonar_run_user }}"
+    backrefs: true # so that it doesn't duplicate, i.e. allows task to be idempotent
 
 - include: configure.yml
 
 - name: Symlink sonar bin.
   file:
-    src: /usr/local/sonar/bin/linux-x86-64/sonar.sh
+    src: "{{ sonar_directory }}/bin/linux-x86-64/sonar.sh"
     dest: /usr/bin/sonar
     state: link
   register: sonar_symlink
 
 - name: Add sonar as init script for service management.
   file:
-    src: /usr/local/sonar/bin/linux-x86-64/sonar.sh
+    src: "{{ sonar_directory }}/bin/linux-x86-64/sonar.sh"
     dest: /etc/init.d/sonar
     state: link
   when: "ansible_service_mgr != 'systemd'"
@@ -50,8 +58,8 @@
   template:
     src: sonar.unit.j2
     dest: /etc/systemd/system/sonar.service
-    owner: root
-    group: root
+    owner: "{{ sonar_run_user }}"
+    group: "{{ sonar_run_group }}"
     mode: 0755
   when: "ansible_service_mgr == 'systemd'"
 

--- a/templates/sonar.unit.j2
+++ b/templates/sonar.unit.j2
@@ -7,7 +7,7 @@ Wants=network-online.target
 ExecStart=/usr/bin/sonar start
 ExecStop=/usr/bin/sonar stop
 ExecReload=/usr/bin/sonar restart
-PIDFile=/usr/local/sonar/bin/linux-x86-64/./SonarQube.pid
+PIDFile={{ sonar_directory }}/bin/linux-x86-64/./SonarQube.pid
 Type=simple
 
 [Install]


### PR DESCRIPTION
Newest version of SonarQube brings in a new version of ElasticSearch, which will fail if it sees you using `root` as the user to run `sonar`

- `sonar_directory` var
- Modify ownership so we comply with ElasticSearch's newest policy of using non-root user
- Add sonar run user and group

