### PR TITLE
AUTO-918: Add memory config changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,13 @@ sonar_mysql_allowed_hosts:
   - "::1"
   - "localhost"
 
+# Storefront has a ton of files to scan, so upping memory here
+sonar_compute_engine_memory_configs: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+
+mysql_config_file: /etc/my.cnf
+mysql_innodb_buffer_pool_size: 256M
+mysql_max_allowed_packet: 256M
+
 # Sonar run user and group.
 sonar_run_user: root
 sonar_run_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ sonar_mysql_allowed_hosts:
 sonar_compute_engine_memory_configs: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 
 mysql_config_file: /etc/my.cnf
-# mysql_innodb_buffer_pool_size: 256M
+mysql_innodb_buffer_pool_size: 2048M
 mysql_max_allowed_packet: 256M
 
 # Sonar run user and group.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,8 @@ sonar_mysql_allowed_hosts:
 
 # Storefront has a ton of files to scan, so upping memory here
 sonar_compute_engine_memory_configs: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+#before I had web to 512, but is this better?
+sonar_web_memory_configs: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 
 mysql_config_file: /etc/my.cnf
 mysql_innodb_buffer_pool_size: 2048M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ sonar_mysql_allowed_hosts:
 sonar_compute_engine_memory_configs: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 
 mysql_config_file: /etc/my.cnf
-mysql_innodb_buffer_pool_size: 256M
+# mysql_innodb_buffer_pool_size: 256M
 mysql_max_allowed_packet: 256M
 
 # Sonar run user and group.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,5 @@ mysql_max_allowed_packet: 256M
 # Sonar run user and group.
 sonar_run_user: root
 sonar_run_group: root
+
+sonar_plugin_urls: []

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,7 +23,7 @@
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items:
-    - regexp: "^innodb_buffer_pool_size"
-      line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
+    # - regexp: "^innodb_buffer_pool_size"
+    #   line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
     - regexp: "^max_allowed_packet"
       line: "max_allowed_packet = {{ mysql_max_allowed_packet }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,7 +23,7 @@
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items:
-    # - regexp: "^innodb_buffer_pool_size"
-    #   line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
+    - regexp: "^innodb_buffer_pool_size"
+      line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
     - regexp: "^max_allowed_packet"
       line: "max_allowed_packet = {{ mysql_max_allowed_packet }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,10 +18,10 @@
       line: "sonar.ce.javaOpts={{ sonar_compute_engine_memory_configs }}"
 
 - name: Configure MySQL memory for handling large packet sizes.
-  lineinfile:
+  replace:
     dest: "{{ mysql_config_file }}"
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
+    regexp: "{{ item.regexp }}(.+)$"
+    replace: "{{ item.line }}"
   with_items:
     - regexp: "^innodb_buffer_pool_size"
       line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure SonarQube JDBC settings for MySQL.
+- name: Configure SonarQube JDBC settings for MySQL and Compute Engine.
   lineinfile:
     dest: "{{ sonar_directory }}/conf/sonar.properties"
     regexp: "{{ item.regexp }}"
@@ -14,3 +14,16 @@
       line: "sonar.jdbc.url=jdbc:mysql://{{ sonar_mysql_host }}:{{ sonar_mysql_port }}/{{ sonar_mysql_database }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true&useConfigs=maxPerformance"
     - regexp: "^sonar.web.context"
       line: "sonar.web.context={{ sonar_web_context }}"
+    - regexp: "^sonar.ce.javaOpts"
+      line: "sonar.ce.javaOpts={{ sonar_compute_engine_memory_configs }}"
+
+- name: Configure MySQL memory for handling large packet sizes
+  lineinfile:
+    dest: "{{ mysql_config_file }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: "^innodb_buffer_pool_size"
+      line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
+    - regexp: "^max_allowed_packet"
+      line: "max_allowed_packet = {{ mysql_max_allowed_packet }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,8 +14,12 @@
       line: "sonar.jdbc.url=jdbc:mysql://{{ sonar_mysql_host }}:{{ sonar_mysql_port }}/{{ sonar_mysql_database }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true&useConfigs=maxPerformance"
     - regexp: "^sonar.web.context"
       line: "sonar.web.context={{ sonar_web_context }}"
+    - regexp: "^(#?)sonar.web.javaOpts=(.*)"
+      line: "sonar.web.javaOpts={{ sonar_web_memory_configs }}"
     - regexp: "^sonar.ce.javaOpts"
       line: "sonar.ce.javaOpts={{ sonar_compute_engine_memory_configs }}"
+    - regexp: "^(#?)sonar.search.javaAdditionalOpts=(.*)"
+      line: "sonar.search.javaAdditionalOpts=-Dbootstrap.system_call_filter=false"
 
 - name: Configure MySQL memory for handling large packet sizes.
   replace:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,7 +17,7 @@
     - regexp: "^sonar.ce.javaOpts"
       line: "sonar.ce.javaOpts={{ sonar_compute_engine_memory_configs }}"
 
-- name: Configure MySQL memory for handling large packet sizes
+- name: Configure MySQL memory for handling large packet sizes.
   lineinfile:
     dest: "{{ mysql_config_file }}"
     regexp: "{{ item.regexp }}"
@@ -27,3 +27,11 @@
       line: "innodb_buffer_pool_size = {{ mysql_innodb_buffer_pool_size }}"
     - regexp: "^max_allowed_packet"
       line: "max_allowed_packet = {{ mysql_max_allowed_packet }}"
+
+- name: Install SonarQube Dependency Check plugin.
+  get_url:
+    url: https://github.com/SonarSecurityCommunity/dependency-check-sonar-plugin/releases/download/1.2.4/sonar-dependency-check-plugin-1.2.4.jar
+    dest: "{{ sonar_directory }}/extensions/plugins"
+    owner: sonar,
+    group: sonar,
+    mode: 0644

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -28,10 +28,10 @@
     - regexp: "^max_allowed_packet"
       line: "max_allowed_packet = {{ mysql_max_allowed_packet }}"
 
-- name: Install SonarQube Dependency Check plugin.
+- name: Install SonarQube plugins
   get_url:
-    url: https://github.com/SonarSecurityCommunity/dependency-check-sonar-plugin/releases/download/1.2.4/sonar-dependency-check-plugin-1.2.4.jar
+    url: "{{ item }}"
     dest: "{{ sonar_directory }}/extensions/plugins"
     owner: sonar
     group: sonar
-    mode: 0644
+  with_items: "{{ sonar_plugin_urls }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,6 +32,6 @@
   get_url:
     url: https://github.com/SonarSecurityCommunity/dependency-check-sonar-plugin/releases/download/1.2.4/sonar-dependency-check-plugin-1.2.4.jar
     dest: "{{ sonar_directory }}/extensions/plugins"
-    owner: sonar,
-    group: sonar,
+    owner: sonar
+    group: sonar
     mode: 0644


### PR DESCRIPTION
*WHAT*: Add MySQL memory config changes, for processing and scanning large amounts of storefront files

[JIRA Ticket](https://renttherunway.jira.com/browse/AUTO-918)

- These values are merely 2x-4x the default amount, in order to give a sizeable buffer as to how much SonarQube can process the scanning of storefront files. Otherwise, you will get errors like this:

```
Error during SonarQube Scanner execution
ERROR: Failed to upload report - HTTP code 413: <html>
<head><title>413 Request Entity Too Large</title></head>
```

```
com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: 
The size of BLOB/TEXT data inserted in one transaction is 
greater than 10% of redo log size. Increase the redo log size using innodb_log_file_size.
```